### PR TITLE
fix: 🐛 TaskListComponentのメモリリーク解消

### DIFF
--- a/src/app/task-list/task-list.component.html
+++ b/src/app/task-list/task-list.component.html
@@ -1,5 +1,5 @@
 <nz-list nzBordered>
-  <nz-list-item *ngFor="let task of tasks">
+  <nz-list-item *ngFor="let task of tasks$ | async">
     <app-task-list-item [task]="task" (updateTask)="updateTask($event)" (deleteTask)="deleteTask($event)"></app-task-list-item>
   </nz-list-item>
   <nz-list-item>

--- a/src/app/task-list/task-list.component.ts
+++ b/src/app/task-list/task-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { fromDocument, Task, TaskDocument } from '../../models/task';
 import { AngularFirestore } from '@angular/fire/firestore';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-task-list',
@@ -13,12 +14,11 @@ export class TaskListComponent implements OnInit {
     private firestore: AngularFirestore,
   ) { }
 
-  tasks: Task[] = [];
+  tasks$ = this.firestore.collection('tasks').valueChanges({idField: 'id'}).pipe(
+    map((tasks: TaskDocument[]) => tasks.map(fromDocument).sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()))
+  );
 
   ngOnInit(): void {
-    this.firestore.collection('tasks').valueChanges({idField: 'id'}).subscribe((tasks: TaskDocument[]) => {
-      this.tasks = tasks.map(fromDocument).sort((a: Task, b: Task) => a.createdAt.getTime() - b.createdAt.getTime());
-    });
   }
 
   addTask(task: Task): void {


### PR DESCRIPTION
`valueChanges`は内部でcompleteしないため、`ngOnDestroy`で`.unsubscribe()`を呼ぶなど手動で開放しないとメモリリークするようです。

Observableを自動的に開放してくれる`async`パイプを使うように変更しました。